### PR TITLE
Add Operator Shell agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS Instructions
+
+This repository hosts the BMAD Method agent assets. The instructions below mirror
+those used in the `OS_candidate` project so the BMAD Agent can be integrated with
+Operator Shell.
+
+## Building the Agent
+
+1. Ensure Node.js is installed.
+2. From the project root, run `node build-web-agent.js` to generate the
+   `build/` directory. The script bundles personas, tasks and templates for the
+   web orchestrator.
+3. After changing any file in `bmad-agent/`, rerun the build script to confirm
+   it completes without errors.
+
+## Development Guidelines
+
+- Keep commits focused and descriptive.
+- Maintain code formatting using your preferred tooling.
+- If tests or lint commands are added, run them before committing.
+
+## Operator Shell Agent
+
+A temporary persona `operator-shell.ide.md` is provided for use with Operator
+Shell via the Roo extension in VS Code.
+
+1. Copy the entire `bmad-agent` folder to your Operator Shell project root.
+2. Load `ide-bmad-orchestrator.md` as a custom mode in Roo.
+3. The orchestrator can become the "Operator Shell" agent defined in the new
+   persona file.
+
+Refer to `docs/instruction.md` for more details on using the BMAD Method.

--- a/bmad-agent/ide-bmad-orchestrator.cfg.md
+++ b/bmad-agent/ide-bmad-orchestrator.cfg.md
@@ -88,3 +88,13 @@ Example: If above cfg has `agent-root: root/foo/` and `tasks: (agent-root)/tasks
 - Persona: "sm.md"
 - Tasks:
   - [Draft Story](create-next-story-task.md)
+
+## Title: Operator Shell Agent
+
+- Name: Roo Agent
+- Customize: ""
+- Description: "Integrates BMAD workflows within Operator Shell via Roo."
+- Persona: "operator-shell.ide.md"
+- Tasks:
+  - [Create Next Story](create-next-story-task.md)
+  - [Correct Course](correct-course.md)

--- a/bmad-agent/personas/operator-shell.ide.md
+++ b/bmad-agent/personas/operator-shell.ide.md
@@ -1,0 +1,17 @@
+# Role: Operator Shell Agent
+
+`taskroot`: `bmad-agent/tasks/`
+`Debug Log`: `.ai/os-debug.md`
+
+## Agent Profile
+
+- **Identity:** Specialized agent for integrating BMAD tasks with Operator Shell.
+- **Focus:** Works through the Roo chat relay in VS Code to help execute BMAD
+  workflows.
+- **Style:** Concise, command-oriented, requests clarification when needed.
+
+## Instructions
+
+- Use tasks like `create-next-story-task.md` and `correct-course.md` as
+  requested.
+- Keep responses short and actionable.


### PR DESCRIPTION
## Summary
- add repo AGENTS guidelines referencing OS_candidate
- introduce `operator-shell.ide.md` persona for temporary Operator Shell integration
- register new persona in orchestrator config

## Testing
- `node build-web-agent.js`