### PR TITLE
Add deployment helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Demo of the BMad Agent entire workflow output from the web agent can be found in
 
 Orchestrator Uber BMad Agent that does it all - already pre-compiled in the `./web-build-sample` folder. You can rebuild if you have node installed from the root of the project with the command `node ./build-web-agent.js`. The contents of agent-prompt.txt in the sample or build output folder should be copied and pasted into the Gemini Gem, or ChatPGT customGPT 'Instructions' field. The remaining files in this folder just need to be attached. Give it a name and save it, and you now have the BMad Agent available to help you brainstorm, research plan and execute on your vision.
 
+For a streamlined workflow that builds the agent and syncs your local repository with GitHub, run the `./deploy-web-agent.sh` script. This will execute the build process, commit any changes, and push them to your current branch.
+
 ![image info](./docs/images/gem-setup.png)
 
 If you are not sure what to do in the Web Agent - try `/help` to get a list of commands, and `/agents` to see what personas BMad can become.

--- a/deploy-web-agent.sh
+++ b/deploy-web-agent.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the web agent assets and push changes to GitHub
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Build the orchestrator assets
+node build-web-agent.js
+
+# Stage all changes (honors .gitignore)
+git add -A
+
+# Commit if there is anything to commit
+if ! git diff --cached --quiet; then
+  git commit -m "chore: build web agent"
+else
+  echo "No changes to commit"
+fi
+
+# Pull latest and push to current branch
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+git pull --rebase origin "$CURRENT_BRANCH"
+git push origin "$CURRENT_BRANCH"
+
+echo "Deployment complete."


### PR DESCRIPTION
## Summary
- add `deploy-web-agent.sh` to build and sync with GitHub
- document deployment script in README

## Testing
- `bash deploy-web-agent.sh` *(fails: no remote)*