### PR TITLE
Add log parsing script and update instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,20 @@
 # AGENTS Instructions
 
-This repository hosts the BMAD Method agent assets. The instructions below mirror
-those used in the `OS_candidate` project so the BMAD Agent can be integrated with
-Operator Shell.
+This repository stores a terminal log (`warp_terminal_log.txt`) that must be processed in discrete jobs. Each job extracts code blocks from a specific line range.
 
-## Building the Agent
+## Workflow
 
-1. Ensure Node.js is installed.
-2. From the project root, run `node build-web-agent.js` to generate the
-   `build/` directory. The script bundles personas, tasks and templates for the
-   web orchestrator.
-3. After changing any file in `bmad-agent/`, rerun the build script to confirm
-   it completes without errors.
+1. Run `scripts/extract_blocks.py` with `--start`, `--end`, and `--job` arguments.
+   Example:
+   ```bash
+   python scripts/extract_blocks.py warp_terminal_log.txt --start 1 --end 200 --job 1
+   ```
+2. The script prints all code blocks found in the range, grouped by filename if one can be detected. Unnamed blocks are labeled `[UNASSIGNED L<start>-<end>]`.
+3. After the blocks, the script outputs the job summary with the next start and end line numbers. Use these values for the subsequent run.
+4. Continue launching the script with updated ranges until the log is fully processed. When the script reports `Job COMPLETE`, all lines have been handled.
 
 ## Development Guidelines
 
 - Keep commits focused and descriptive.
-- Maintain code formatting using your preferred tooling.
-- If tests or lint commands are added, run them before committing.
-
-## Operator Shell Agent
-
-A temporary persona `operator-shell.ide.md` is provided for use with Operator
-Shell via the Roo extension in VS Code.
-
-1. Copy the entire `bmad-agent` folder to your Operator Shell project root.
-2. Load `ide-bmad-orchestrator.md` as a custom mode in Roo.
-3. The orchestrator can become the "Operator Shell" agent defined in the new
-   persona file.
-
-Refer to `docs/instruction.md` for more details on using the BMAD Method.
+- Maintain code formatting using your preferred tools.
+- If you modify any part of `bmad-agent/`, run `node build-web-agent.js` to rebuild before committing.

--- a/scripts/extract_blocks.py
+++ b/scripts/extract_blocks.py
@@ -1,0 +1,96 @@
+import argparse
+import os
+import re
+from collections import defaultdict
+
+BLOCK_RE = re.compile(r"^```(.*)")
+FILE_HINT_RE = re.compile(r"^[+]*\+\+\+\s+(.*)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Extract code blocks from log file")
+    p.add_argument("logfile", help="Path to terminal log")
+    p.add_argument("--start", type=int, required=True, help="Start line number (1-indexed)")
+    p.add_argument("--end", type=int, required=True, help="End line number (inclusive)")
+    p.add_argument("--job", type=int, required=True, help="Job index")
+    return p.parse_args()
+
+
+def load_lines(path):
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        return f.readlines()
+
+
+def extract_blocks(lines, start, end):
+    results = defaultdict(list)
+    in_block = False
+    block_lines = []
+    file_hint = None
+    block_file = None
+    block_start = start
+
+    for idx in range(start - 1, end):
+        line = lines[idx]
+        line_no = idx + 1
+        file_hint_match = FILE_HINT_RE.match(line)
+        if file_hint_match:
+            file_hint = file_hint_match.group(1).strip()
+
+        m = BLOCK_RE.match(line.strip())
+        if m:
+            header = m.group(1).strip()
+            if not in_block:
+                in_block = True
+                block_lines = [line.rstrip("\n")]
+                block_start = line_no
+                parts = header.split()
+                if len(parts) > 1:
+                    block_file = " ".join(parts[1:])
+                elif parts and ("/" in parts[0] or "\\" in parts[0]):
+                    block_file = parts[0]
+                else:
+                    block_file = file_hint
+            else:
+                block_lines.append(line.rstrip("\n"))
+                key = block_file or f"[UNASSIGNED L{block_start}-{line_no}]"
+                results[key].append("\n".join(block_lines))
+                in_block = False
+                block_lines = []
+                block_file = None
+        else:
+            if in_block:
+                block_lines.append(line.rstrip("\n"))
+
+    if in_block:
+        key = block_file or f"[UNASSIGNED L{block_start}-{end}]"
+        results[key].append("\n".join(block_lines))
+
+    return results
+
+
+def main():
+    args = parse_args()
+    lines = load_lines(args.logfile)
+    total_lines = len(lines)
+    end = min(args.end, total_lines)
+    blocks = extract_blocks(lines, args.start, end)
+
+    for fname, blist in blocks.items():
+        print(f"# {fname}")
+        for b in blist:
+            print(b)
+            print()
+
+    print(f"Job {args.job}")
+    print(f"Lines processed: {end - args.start + 1}")
+    next_start = end + 1
+    next_end = next_start + (args.end - args.start)
+    if next_start > total_lines:
+        print("Job COMPLETE")
+    else:
+        print(f"Next start: {next_start}")
+        print(f"Next end: {next_end if next_end <= total_lines else total_lines}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python helper `scripts/extract_blocks.py` to parse `warp_terminal_log.txt`
- replace `AGENTS.md` with new workflow instructions for using the script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688996684a18832fa30e9edcace500fd