### PR TITLE
Fix detection of diff-prefixed code fences

### DIFF
--- a/scripts/extract_blocks.py
+++ b/scripts/extract_blocks.py
@@ -3,7 +3,8 @@ import os
 import re
 from collections import defaultdict
 
-BLOCK_RE = re.compile(r"^```(.*)")
+# Match code fence lines that may be prefixed with '+' characters from diff
+BLOCK_RE = re.compile(r"^\+*```(.*)")
 FILE_HINT_RE = re.compile(r"^[+]*\+\+\+\s+(.*)")
 
 


### PR DESCRIPTION
## Summary
- update regex in `extract_blocks.py` to handle code fences prefixed with '+'

## Testing
- `python scripts/extract_blocks.py warp_terminal_log.txt --start 3401 --end 3600 --job 18 | head`

------
https://chatgpt.com/codex/tasks/task_e_688999a2c51c832f824a9a52a53b69b4